### PR TITLE
Changes to url and ux.

### DIFF
--- a/cmd/update-index/data/index.html.template
+++ b/cmd/update-index/data/index.html.template
@@ -60,7 +60,7 @@
             </div>
             <div class="level-item has-text-centered">
                 <div>
-                    <p class="heading">Versions</p>
+                    <p class="heading">Stable Versions</p>
                     <div class="buttons has-addons" id="version">
                         {{range .AllVersions}}<span class="button" data-version="{{clean .}}">{{.}}</span>
                     {{end}}</div>
@@ -73,8 +73,8 @@
                     <th>Version</th>
                     <th>Operating System</th>
                     <th>Architecture</th>
-                    <th>Binary</th>
-                    <th>Download Link</th>
+                    <th>Download Binary</th>
+                    <th>Copy Link</th>
                 </tr>
             </thead>
             <tbody>

--- a/cmd/update-index/main.go
+++ b/cmd/update-index/main.go
@@ -102,12 +102,12 @@ func (b Binary) Row() string {
 	<td>%s</td>
 	<td>%s</td>
 	<td>%s</td>
-	<td>%s</td>
-	<td><a class="copy" href="%s">copy link</a></td>`, b.Version, b.OperatingSystem, b.Architecture, b.Name, b.downloadLink())
+    <td><span title="download"><a href="https://%s">%s</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://%s">  %s</a></span></td>`, b.Version, b.OperatingSystem, b.Architecture, b.downloadLink(), b.Name, b.downloadLink(), b.downloadLink())
 	return fmt.Sprintf(tr, rows)
 }
 func (b Binary) downloadLink() string {
-	return fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/%s", b.Version, b.OperatingSystem, b.Architecture, b.Name)
+	return fmt.Sprintf("dl.k8s.io/%s/bin/%s/%s/%s", b.Version, b.OperatingSystem, b.Architecture, b.Name)
 }
 
 func (b Binary) version() version {

--- a/dist/index.html
+++ b/dist/index.html
@@ -67,13 +67,13 @@
             </div>
             <div class="level-item has-text-centered">
                 <div>
-                    <p class="heading">Versions</p>
+                    <p class="heading">Stable Versions</p>
                     <div class="buttons has-addons" id="version">
-                        <span class="button" data-version="v1-15-2">v1.15.2</span>
-                    <span class="button" data-version="v1-14-5">v1.14.5</span>
-                    <span class="button" data-version="v1-13-9">v1.13.9</span>
-                    <span class="button" data-version="v1-12-10">v1.12.10</span>
-                    <span class="button" data-version="v1-11-10">v1.11.10</span>
+                        <span class="button" data-version="v1-17-4">v1.17.4</span>
+                    <span class="button" data-version="v1-16-8">v1.16.8</span>
+                    <span class="button" data-version="v1-15-11">v1.15.11</span>
+                    <span class="button" data-version="v1-14-10">v1.14.10</span>
+                    <span class="button" data-version="v1-13-12">v1.13.12</span>
                     </div>
                 </div>
             </div>
@@ -84,1612 +84,1512 @@
                     <th>Version</th>
                     <th>Operating System</th>
                     <th>Architecture</th>
-                    <th>Binary</th>
-                    <th>Download Link</th>
+                    <th>Download Binary</th>
+                    <th>Copy Link</th>
                 </tr>
             </thead>
             <tbody>
-<tr class="v1-15-2 darwin a-386 kubectl">
-	<td>v1.15.2</td>
+<tr class="v1-17-4 darwin a-386 kubectl">
+	<td>v1.17.4</td>
 	<td>darwin</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/darwin/386/kubectl">copy link</a></td></tr><tr class="v1-15-2 darwin amd64 kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/darwin/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/darwin/386/kubectl">  dl.k8s.io/v1.17.4/bin/darwin/386/kubectl</a></span></td></tr><tr class="v1-17-4 darwin amd64 kubectl">
+	<td>v1.17.4</td>
 	<td>darwin</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/darwin/amd64/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux a-386 kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/darwin/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/darwin/amd64/kubectl">  dl.k8s.io/v1.17.4/bin/darwin/amd64/kubectl</a></span></td></tr><tr class="v1-17-4 linux a-386 kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/386/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux amd64 apiextensions-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/386/kubectl">  dl.k8s.io/v1.17.4/bin/linux/386/kubectl</a></span></td></tr><tr class="v1-17-4 linux amd64 apiextensions-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux amd64 cloud-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/apiextensions-apiserver">  dl.k8s.io/v1.17.4/bin/linux/amd64/apiextensions-apiserver</a></span></td></tr><tr class="v1-17-4 linux amd64 kube-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux amd64 hyperkube">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-apiserver">  dl.k8s.io/v1.17.4/bin/linux/amd64/kube-apiserver</a></span></td></tr><tr class="v1-17-4 linux amd64 kube-controller-manager">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/hyperkube">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kube-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-controller-manager">  dl.k8s.io/v1.17.4/bin/linux/amd64/kube-controller-manager</a></span></td></tr><tr class="v1-17-4 linux amd64 kube-proxy">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kube-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kube-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-proxy">  dl.k8s.io/v1.17.4/bin/linux/amd64/kube-proxy</a></span></td></tr><tr class="v1-17-4 linux amd64 kube-scheduler">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kube-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kube-proxy">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kube-scheduler">  dl.k8s.io/v1.17.4/bin/linux/amd64/kube-scheduler</a></span></td></tr><tr class="v1-17-4 linux amd64 kubeadm">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kube-proxy">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kube-scheduler">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubeadm">  dl.k8s.io/v1.17.4/bin/linux/amd64/kubeadm</a></span></td></tr><tr class="v1-17-4 linux amd64 kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kube-scheduler">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kubeadm">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubectl">  dl.k8s.io/v1.17.4/bin/linux/amd64/kubectl</a></span></td></tr><tr class="v1-17-4 linux amd64 kubelet">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kubeadm">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/kubelet">  dl.k8s.io/v1.17.4/bin/linux/amd64/kubelet</a></span></td></tr><tr class="v1-17-4 linux amd64 mounter">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux amd64 kubelet">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>amd64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kubelet">copy link</a></td></tr><tr class="v1-15-2 linux amd64 mounter">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>amd64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/mounter">copy link</a></td></tr><tr class="v1-15-2 linux arm apiextensions-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/amd64/mounter">  dl.k8s.io/v1.17.4/bin/linux/amd64/mounter</a></span></td></tr><tr class="v1-17-4 linux arm apiextensions-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux arm cloud-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/apiextensions-apiserver">  dl.k8s.io/v1.17.4/bin/linux/arm/apiextensions-apiserver</a></span></td></tr><tr class="v1-17-4 linux arm kube-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/cloud-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux arm hyperkube">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-apiserver">  dl.k8s.io/v1.17.4/bin/linux/arm/kube-apiserver</a></span></td></tr><tr class="v1-17-4 linux arm kube-controller-manager">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/hyperkube">copy link</a></td></tr><tr class="v1-15-2 linux arm kube-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-controller-manager">  dl.k8s.io/v1.17.4/bin/linux/arm/kube-controller-manager</a></span></td></tr><tr class="v1-17-4 linux arm kube-proxy">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kube-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux arm kube-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-proxy">  dl.k8s.io/v1.17.4/bin/linux/arm/kube-proxy</a></span></td></tr><tr class="v1-17-4 linux arm kube-scheduler">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kube-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux arm kube-proxy">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kube-scheduler">  dl.k8s.io/v1.17.4/bin/linux/arm/kube-scheduler</a></span></td></tr><tr class="v1-17-4 linux arm kubeadm">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kube-proxy">copy link</a></td></tr><tr class="v1-15-2 linux arm kube-scheduler">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubeadm">  dl.k8s.io/v1.17.4/bin/linux/arm/kubeadm</a></span></td></tr><tr class="v1-17-4 linux arm kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kube-scheduler">copy link</a></td></tr><tr class="v1-15-2 linux arm kubeadm">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubectl">  dl.k8s.io/v1.17.4/bin/linux/arm/kubectl</a></span></td></tr><tr class="v1-17-4 linux arm kubelet">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kubeadm">copy link</a></td></tr><tr class="v1-15-2 linux arm kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/kubelet">  dl.k8s.io/v1.17.4/bin/linux/arm/kubelet</a></span></td></tr><tr class="v1-17-4 linux arm mounter">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux arm kubelet">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>arm</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/kubelet">copy link</a></td></tr><tr class="v1-15-2 linux arm mounter">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>arm</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm/mounter">copy link</a></td></tr><tr class="v1-15-2 linux arm64 apiextensions-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm/mounter">  dl.k8s.io/v1.17.4/bin/linux/arm/mounter</a></span></td></tr><tr class="v1-17-4 linux arm64 apiextensions-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux arm64 cloud-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/apiextensions-apiserver">  dl.k8s.io/v1.17.4/bin/linux/arm64/apiextensions-apiserver</a></span></td></tr><tr class="v1-17-4 linux arm64 kube-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux arm64 hyperkube">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-apiserver">  dl.k8s.io/v1.17.4/bin/linux/arm64/kube-apiserver</a></span></td></tr><tr class="v1-17-4 linux arm64 kube-controller-manager">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/hyperkube">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kube-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-controller-manager">  dl.k8s.io/v1.17.4/bin/linux/arm64/kube-controller-manager</a></span></td></tr><tr class="v1-17-4 linux arm64 kube-proxy">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kube-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kube-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-proxy">  dl.k8s.io/v1.17.4/bin/linux/arm64/kube-proxy</a></span></td></tr><tr class="v1-17-4 linux arm64 kube-scheduler">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kube-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kube-proxy">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kube-scheduler">  dl.k8s.io/v1.17.4/bin/linux/arm64/kube-scheduler</a></span></td></tr><tr class="v1-17-4 linux arm64 kubeadm">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kube-proxy">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kube-scheduler">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubeadm">  dl.k8s.io/v1.17.4/bin/linux/arm64/kubeadm</a></span></td></tr><tr class="v1-17-4 linux arm64 kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kube-scheduler">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kubeadm">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubectl">  dl.k8s.io/v1.17.4/bin/linux/arm64/kubectl</a></span></td></tr><tr class="v1-17-4 linux arm64 kubelet">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kubeadm">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/kubelet">  dl.k8s.io/v1.17.4/bin/linux/arm64/kubelet</a></span></td></tr><tr class="v1-17-4 linux arm64 mounter">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux arm64 kubelet">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>arm64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/kubelet">copy link</a></td></tr><tr class="v1-15-2 linux arm64 mounter">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>arm64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/arm64/mounter">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le apiextensions-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/arm64/mounter">  dl.k8s.io/v1.17.4/bin/linux/arm64/mounter</a></span></td></tr><tr class="v1-17-4 linux ppc64le apiextensions-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le cloud-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/apiextensions-apiserver">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/apiextensions-apiserver</a></span></td></tr><tr class="v1-17-4 linux ppc64le kube-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/cloud-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le hyperkube">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-apiserver">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-apiserver</a></span></td></tr><tr class="v1-17-4 linux ppc64le kube-controller-manager">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/hyperkube">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kube-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-controller-manager">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-controller-manager</a></span></td></tr><tr class="v1-17-4 linux ppc64le kube-proxy">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kube-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kube-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-proxy">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-proxy</a></span></td></tr><tr class="v1-17-4 linux ppc64le kube-scheduler">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kube-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kube-proxy">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-scheduler">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kube-scheduler</a></span></td></tr><tr class="v1-17-4 linux ppc64le kubeadm">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kube-proxy">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kube-scheduler">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubeadm">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubeadm</a></span></td></tr><tr class="v1-17-4 linux ppc64le kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kube-scheduler">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kubeadm">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubectl">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubectl</a></span></td></tr><tr class="v1-17-4 linux ppc64le kubelet">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kubeadm">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubelet">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/kubelet</a></span></td></tr><tr class="v1-17-4 linux ppc64le mounter">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le kubelet">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>ppc64le</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/kubelet">copy link</a></td></tr><tr class="v1-15-2 linux ppc64le mounter">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>ppc64le</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/ppc64le/mounter">copy link</a></td></tr><tr class="v1-15-2 linux s390x apiextensions-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/ppc64le/mounter">  dl.k8s.io/v1.17.4/bin/linux/ppc64le/mounter</a></span></td></tr><tr class="v1-17-4 linux s390x apiextensions-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux s390x cloud-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/apiextensions-apiserver">  dl.k8s.io/v1.17.4/bin/linux/s390x/apiextensions-apiserver</a></span></td></tr><tr class="v1-17-4 linux s390x kube-apiserver">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/cloud-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux s390x hyperkube">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-apiserver">  dl.k8s.io/v1.17.4/bin/linux/s390x/kube-apiserver</a></span></td></tr><tr class="v1-17-4 linux s390x kube-controller-manager">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/hyperkube">copy link</a></td></tr><tr class="v1-15-2 linux s390x kube-apiserver">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-controller-manager">  dl.k8s.io/v1.17.4/bin/linux/s390x/kube-controller-manager</a></span></td></tr><tr class="v1-17-4 linux s390x kube-proxy">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kube-apiserver">copy link</a></td></tr><tr class="v1-15-2 linux s390x kube-controller-manager">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-proxy">  dl.k8s.io/v1.17.4/bin/linux/s390x/kube-proxy</a></span></td></tr><tr class="v1-17-4 linux s390x kube-scheduler">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kube-controller-manager">copy link</a></td></tr><tr class="v1-15-2 linux s390x kube-proxy">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kube-scheduler">  dl.k8s.io/v1.17.4/bin/linux/s390x/kube-scheduler</a></span></td></tr><tr class="v1-17-4 linux s390x kubeadm">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kube-proxy">copy link</a></td></tr><tr class="v1-15-2 linux s390x kube-scheduler">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubeadm">  dl.k8s.io/v1.17.4/bin/linux/s390x/kubeadm</a></span></td></tr><tr class="v1-17-4 linux s390x kubectl">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kube-scheduler">copy link</a></td></tr><tr class="v1-15-2 linux s390x kubeadm">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubectl">  dl.k8s.io/v1.17.4/bin/linux/s390x/kubectl</a></span></td></tr><tr class="v1-17-4 linux s390x kubelet">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kubeadm">copy link</a></td></tr><tr class="v1-15-2 linux s390x kubectl">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/kubelet">  dl.k8s.io/v1.17.4/bin/linux/s390x/kubelet</a></span></td></tr><tr class="v1-17-4 linux s390x mounter">
+	<td>v1.17.4</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kubectl">copy link</a></td></tr><tr class="v1-15-2 linux s390x kubelet">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>s390x</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/kubelet">copy link</a></td></tr><tr class="v1-15-2 linux s390x mounter">
-	<td>v1.15.2</td>
-	<td>linux</td>
-	<td>s390x</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/s390x/mounter">copy link</a></td></tr><tr class="v1-15-2 windows a-386 kubectl.exe">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/linux/s390x/mounter">  dl.k8s.io/v1.17.4/bin/linux/s390x/mounter</a></span></td></tr><tr class="v1-17-4 windows a-386 kubectl.exe">
+	<td>v1.17.4</td>
 	<td>windows</td>
 	<td>386</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/windows/386/kubectl.exe">copy link</a></td></tr><tr class="v1-15-2 windows amd64 kube-proxy.exe">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/windows/386/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/windows/386/kubectl.exe">  dl.k8s.io/v1.17.4/bin/windows/386/kubectl.exe</a></span></td></tr><tr class="v1-17-4 windows amd64 kube-proxy.exe">
+	<td>v1.17.4</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kube-proxy.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/windows/amd64/kube-proxy.exe">copy link</a></td></tr><tr class="v1-15-2 windows amd64 kubeadm.exe">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kube-proxy.exe">  dl.k8s.io/v1.17.4/bin/windows/amd64/kube-proxy.exe</a></span></td></tr><tr class="v1-17-4 windows amd64 kubeadm.exe">
+	<td>v1.17.4</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubeadm.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/windows/amd64/kubeadm.exe">copy link</a></td></tr><tr class="v1-15-2 windows amd64 kubectl.exe">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubeadm.exe">  dl.k8s.io/v1.17.4/bin/windows/amd64/kubeadm.exe</a></span></td></tr><tr class="v1-17-4 windows amd64 kubectl.exe">
+	<td>v1.17.4</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/windows/amd64/kubectl.exe">copy link</a></td></tr><tr class="v1-15-2 windows amd64 kubelet.exe">
-	<td>v1.15.2</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubectl.exe">  dl.k8s.io/v1.17.4/bin/windows/amd64/kubectl.exe</a></span></td></tr><tr class="v1-17-4 windows amd64 kubelet.exe">
+	<td>v1.17.4</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubelet.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/windows/amd64/kubelet.exe">copy link</a></td></tr><tr class="v1-14-5 darwin a-386 kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubelet.exe">kubelet.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.17.4/bin/windows/amd64/kubelet.exe">  dl.k8s.io/v1.17.4/bin/windows/amd64/kubelet.exe</a></span></td></tr><tr class="v1-16-8 darwin a-386 kubectl">
+	<td>v1.16.8</td>
 	<td>darwin</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/darwin/386/kubectl">copy link</a></td></tr><tr class="v1-14-5 darwin amd64 kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/darwin/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/darwin/386/kubectl">  dl.k8s.io/v1.16.8/bin/darwin/386/kubectl</a></span></td></tr><tr class="v1-16-8 darwin amd64 kubectl">
+	<td>v1.16.8</td>
 	<td>darwin</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/darwin/amd64/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux a-386 kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/darwin/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/darwin/amd64/kubectl">  dl.k8s.io/v1.16.8/bin/darwin/amd64/kubectl</a></span></td></tr><tr class="v1-16-8 linux a-386 kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/386/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux amd64 apiextensions-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/386/kubectl">  dl.k8s.io/v1.16.8/bin/linux/386/kubectl</a></span></td></tr><tr class="v1-16-8 linux amd64 apiextensions-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux amd64 cloud-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/apiextensions-apiserver">  dl.k8s.io/v1.16.8/bin/linux/amd64/apiextensions-apiserver</a></span></td></tr><tr class="v1-16-8 linux amd64 hyperkube">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux amd64 hyperkube">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/hyperkube">  dl.k8s.io/v1.16.8/bin/linux/amd64/hyperkube</a></span></td></tr><tr class="v1-16-8 linux amd64 kube-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/hyperkube">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kube-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-apiserver">  dl.k8s.io/v1.16.8/bin/linux/amd64/kube-apiserver</a></span></td></tr><tr class="v1-16-8 linux amd64 kube-controller-manager">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kube-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kube-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-controller-manager">  dl.k8s.io/v1.16.8/bin/linux/amd64/kube-controller-manager</a></span></td></tr><tr class="v1-16-8 linux amd64 kube-proxy">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kube-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kube-proxy">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-proxy">  dl.k8s.io/v1.16.8/bin/linux/amd64/kube-proxy</a></span></td></tr><tr class="v1-16-8 linux amd64 kube-scheduler">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kube-proxy">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kube-scheduler">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kube-scheduler">  dl.k8s.io/v1.16.8/bin/linux/amd64/kube-scheduler</a></span></td></tr><tr class="v1-16-8 linux amd64 kubeadm">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kube-scheduler">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kubeadm">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubeadm">  dl.k8s.io/v1.16.8/bin/linux/amd64/kubeadm</a></span></td></tr><tr class="v1-16-8 linux amd64 kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kubeadm">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubectl">  dl.k8s.io/v1.16.8/bin/linux/amd64/kubectl</a></span></td></tr><tr class="v1-16-8 linux amd64 kubelet">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux amd64 kubelet">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/kubelet">  dl.k8s.io/v1.16.8/bin/linux/amd64/kubelet</a></span></td></tr><tr class="v1-16-8 linux amd64 mounter">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kubelet">copy link</a></td></tr><tr class="v1-14-5 linux amd64 mounter">
-	<td>v1.14.5</td>
-	<td>linux</td>
-	<td>amd64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/mounter">copy link</a></td></tr><tr class="v1-14-5 linux arm apiextensions-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/amd64/mounter">  dl.k8s.io/v1.16.8/bin/linux/amd64/mounter</a></span></td></tr><tr class="v1-16-8 linux arm apiextensions-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux arm cloud-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/apiextensions-apiserver">  dl.k8s.io/v1.16.8/bin/linux/arm/apiextensions-apiserver</a></span></td></tr><tr class="v1-16-8 linux arm hyperkube">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/cloud-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux arm hyperkube">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/hyperkube">  dl.k8s.io/v1.16.8/bin/linux/arm/hyperkube</a></span></td></tr><tr class="v1-16-8 linux arm kube-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/hyperkube">copy link</a></td></tr><tr class="v1-14-5 linux arm kube-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-apiserver">  dl.k8s.io/v1.16.8/bin/linux/arm/kube-apiserver</a></span></td></tr><tr class="v1-16-8 linux arm kube-controller-manager">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kube-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux arm kube-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-controller-manager">  dl.k8s.io/v1.16.8/bin/linux/arm/kube-controller-manager</a></span></td></tr><tr class="v1-16-8 linux arm kube-proxy">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kube-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux arm kube-proxy">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-proxy">  dl.k8s.io/v1.16.8/bin/linux/arm/kube-proxy</a></span></td></tr><tr class="v1-16-8 linux arm kube-scheduler">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kube-proxy">copy link</a></td></tr><tr class="v1-14-5 linux arm kube-scheduler">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kube-scheduler">  dl.k8s.io/v1.16.8/bin/linux/arm/kube-scheduler</a></span></td></tr><tr class="v1-16-8 linux arm kubeadm">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kube-scheduler">copy link</a></td></tr><tr class="v1-14-5 linux arm kubeadm">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubeadm">  dl.k8s.io/v1.16.8/bin/linux/arm/kubeadm</a></span></td></tr><tr class="v1-16-8 linux arm kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kubeadm">copy link</a></td></tr><tr class="v1-14-5 linux arm kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubectl">  dl.k8s.io/v1.16.8/bin/linux/arm/kubectl</a></span></td></tr><tr class="v1-16-8 linux arm kubelet">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux arm kubelet">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/kubelet">  dl.k8s.io/v1.16.8/bin/linux/arm/kubelet</a></span></td></tr><tr class="v1-16-8 linux arm mounter">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/kubelet">copy link</a></td></tr><tr class="v1-14-5 linux arm mounter">
-	<td>v1.14.5</td>
-	<td>linux</td>
-	<td>arm</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm/mounter">copy link</a></td></tr><tr class="v1-14-5 linux arm64 apiextensions-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm/mounter">  dl.k8s.io/v1.16.8/bin/linux/arm/mounter</a></span></td></tr><tr class="v1-16-8 linux arm64 apiextensions-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux arm64 cloud-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/apiextensions-apiserver">  dl.k8s.io/v1.16.8/bin/linux/arm64/apiextensions-apiserver</a></span></td></tr><tr class="v1-16-8 linux arm64 hyperkube">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux arm64 hyperkube">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/hyperkube">  dl.k8s.io/v1.16.8/bin/linux/arm64/hyperkube</a></span></td></tr><tr class="v1-16-8 linux arm64 kube-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/hyperkube">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kube-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-apiserver">  dl.k8s.io/v1.16.8/bin/linux/arm64/kube-apiserver</a></span></td></tr><tr class="v1-16-8 linux arm64 kube-controller-manager">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kube-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kube-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-controller-manager">  dl.k8s.io/v1.16.8/bin/linux/arm64/kube-controller-manager</a></span></td></tr><tr class="v1-16-8 linux arm64 kube-proxy">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kube-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kube-proxy">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-proxy">  dl.k8s.io/v1.16.8/bin/linux/arm64/kube-proxy</a></span></td></tr><tr class="v1-16-8 linux arm64 kube-scheduler">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kube-proxy">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kube-scheduler">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kube-scheduler">  dl.k8s.io/v1.16.8/bin/linux/arm64/kube-scheduler</a></span></td></tr><tr class="v1-16-8 linux arm64 kubeadm">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kube-scheduler">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kubeadm">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubeadm">  dl.k8s.io/v1.16.8/bin/linux/arm64/kubeadm</a></span></td></tr><tr class="v1-16-8 linux arm64 kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kubeadm">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubectl">  dl.k8s.io/v1.16.8/bin/linux/arm64/kubectl</a></span></td></tr><tr class="v1-16-8 linux arm64 kubelet">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux arm64 kubelet">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/kubelet">  dl.k8s.io/v1.16.8/bin/linux/arm64/kubelet</a></span></td></tr><tr class="v1-16-8 linux arm64 mounter">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/kubelet">copy link</a></td></tr><tr class="v1-14-5 linux arm64 mounter">
-	<td>v1.14.5</td>
-	<td>linux</td>
-	<td>arm64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/arm64/mounter">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le apiextensions-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/arm64/mounter">  dl.k8s.io/v1.16.8/bin/linux/arm64/mounter</a></span></td></tr><tr class="v1-16-8 linux ppc64le apiextensions-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le cloud-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/apiextensions-apiserver">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/apiextensions-apiserver</a></span></td></tr><tr class="v1-16-8 linux ppc64le hyperkube">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/cloud-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le hyperkube">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/hyperkube">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/hyperkube</a></span></td></tr><tr class="v1-16-8 linux ppc64le kube-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/hyperkube">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kube-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-apiserver">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-apiserver</a></span></td></tr><tr class="v1-16-8 linux ppc64le kube-controller-manager">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kube-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kube-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-controller-manager">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-controller-manager</a></span></td></tr><tr class="v1-16-8 linux ppc64le kube-proxy">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kube-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kube-proxy">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-proxy">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-proxy</a></span></td></tr><tr class="v1-16-8 linux ppc64le kube-scheduler">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kube-proxy">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kube-scheduler">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-scheduler">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kube-scheduler</a></span></td></tr><tr class="v1-16-8 linux ppc64le kubeadm">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kube-scheduler">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kubeadm">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubeadm">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubeadm</a></span></td></tr><tr class="v1-16-8 linux ppc64le kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kubeadm">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubectl">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubectl</a></span></td></tr><tr class="v1-16-8 linux ppc64le kubelet">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le kubelet">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubelet">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/kubelet</a></span></td></tr><tr class="v1-16-8 linux ppc64le mounter">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/kubelet">copy link</a></td></tr><tr class="v1-14-5 linux ppc64le mounter">
-	<td>v1.14.5</td>
-	<td>linux</td>
-	<td>ppc64le</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/ppc64le/mounter">copy link</a></td></tr><tr class="v1-14-5 linux s390x apiextensions-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/ppc64le/mounter">  dl.k8s.io/v1.16.8/bin/linux/ppc64le/mounter</a></span></td></tr><tr class="v1-16-8 linux s390x apiextensions-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux s390x cloud-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/apiextensions-apiserver">  dl.k8s.io/v1.16.8/bin/linux/s390x/apiextensions-apiserver</a></span></td></tr><tr class="v1-16-8 linux s390x hyperkube">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/cloud-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux s390x hyperkube">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/hyperkube">  dl.k8s.io/v1.16.8/bin/linux/s390x/hyperkube</a></span></td></tr><tr class="v1-16-8 linux s390x kube-apiserver">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/hyperkube">copy link</a></td></tr><tr class="v1-14-5 linux s390x kube-apiserver">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-apiserver">  dl.k8s.io/v1.16.8/bin/linux/s390x/kube-apiserver</a></span></td></tr><tr class="v1-16-8 linux s390x kube-controller-manager">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kube-apiserver">copy link</a></td></tr><tr class="v1-14-5 linux s390x kube-controller-manager">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-controller-manager">  dl.k8s.io/v1.16.8/bin/linux/s390x/kube-controller-manager</a></span></td></tr><tr class="v1-16-8 linux s390x kube-proxy">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kube-controller-manager">copy link</a></td></tr><tr class="v1-14-5 linux s390x kube-proxy">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-proxy">  dl.k8s.io/v1.16.8/bin/linux/s390x/kube-proxy</a></span></td></tr><tr class="v1-16-8 linux s390x kube-scheduler">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kube-proxy">copy link</a></td></tr><tr class="v1-14-5 linux s390x kube-scheduler">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kube-scheduler">  dl.k8s.io/v1.16.8/bin/linux/s390x/kube-scheduler</a></span></td></tr><tr class="v1-16-8 linux s390x kubeadm">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kube-scheduler">copy link</a></td></tr><tr class="v1-14-5 linux s390x kubeadm">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubeadm">  dl.k8s.io/v1.16.8/bin/linux/s390x/kubeadm</a></span></td></tr><tr class="v1-16-8 linux s390x kubectl">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kubeadm">copy link</a></td></tr><tr class="v1-14-5 linux s390x kubectl">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubectl">  dl.k8s.io/v1.16.8/bin/linux/s390x/kubectl</a></span></td></tr><tr class="v1-16-8 linux s390x kubelet">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kubectl">copy link</a></td></tr><tr class="v1-14-5 linux s390x kubelet">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/kubelet">  dl.k8s.io/v1.16.8/bin/linux/s390x/kubelet</a></span></td></tr><tr class="v1-16-8 linux s390x mounter">
+	<td>v1.16.8</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/kubelet">copy link</a></td></tr><tr class="v1-14-5 linux s390x mounter">
-	<td>v1.14.5</td>
-	<td>linux</td>
-	<td>s390x</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/s390x/mounter">copy link</a></td></tr><tr class="v1-14-5 windows a-386 kubectl.exe">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/linux/s390x/mounter">  dl.k8s.io/v1.16.8/bin/linux/s390x/mounter</a></span></td></tr><tr class="v1-16-8 windows a-386 kubectl.exe">
+	<td>v1.16.8</td>
 	<td>windows</td>
 	<td>386</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/windows/386/kubectl.exe">copy link</a></td></tr><tr class="v1-14-5 windows amd64 kube-proxy.exe">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/windows/386/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/windows/386/kubectl.exe">  dl.k8s.io/v1.16.8/bin/windows/386/kubectl.exe</a></span></td></tr><tr class="v1-16-8 windows amd64 kube-proxy.exe">
+	<td>v1.16.8</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kube-proxy.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/windows/amd64/kube-proxy.exe">copy link</a></td></tr><tr class="v1-14-5 windows amd64 kubeadm.exe">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kube-proxy.exe">  dl.k8s.io/v1.16.8/bin/windows/amd64/kube-proxy.exe</a></span></td></tr><tr class="v1-16-8 windows amd64 kubeadm.exe">
+	<td>v1.16.8</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubeadm.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/windows/amd64/kubeadm.exe">copy link</a></td></tr><tr class="v1-14-5 windows amd64 kubectl.exe">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubeadm.exe">  dl.k8s.io/v1.16.8/bin/windows/amd64/kubeadm.exe</a></span></td></tr><tr class="v1-16-8 windows amd64 kubectl.exe">
+	<td>v1.16.8</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/windows/amd64/kubectl.exe">copy link</a></td></tr><tr class="v1-14-5 windows amd64 kubelet.exe">
-	<td>v1.14.5</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubectl.exe">  dl.k8s.io/v1.16.8/bin/windows/amd64/kubectl.exe</a></span></td></tr><tr class="v1-16-8 windows amd64 kubelet.exe">
+	<td>v1.16.8</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubelet.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/windows/amd64/kubelet.exe">copy link</a></td></tr><tr class="v1-13-9 darwin a-386 kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubelet.exe">kubelet.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.16.8/bin/windows/amd64/kubelet.exe">  dl.k8s.io/v1.16.8/bin/windows/amd64/kubelet.exe</a></span></td></tr><tr class="v1-15-11 darwin a-386 kubectl">
+	<td>v1.15.11</td>
 	<td>darwin</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/darwin/386/kubectl">copy link</a></td></tr><tr class="v1-13-9 darwin amd64 kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/darwin/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/darwin/386/kubectl">  dl.k8s.io/v1.15.11/bin/darwin/386/kubectl</a></span></td></tr><tr class="v1-15-11 darwin amd64 kubectl">
+	<td>v1.15.11</td>
 	<td>darwin</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/darwin/amd64/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux a-386 kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/darwin/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/darwin/amd64/kubectl">  dl.k8s.io/v1.15.11/bin/darwin/amd64/kubectl</a></span></td></tr><tr class="v1-15-11 linux a-386 kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/386/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux amd64 apiextensions-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/386/kubectl">  dl.k8s.io/v1.15.11/bin/linux/386/kubectl</a></span></td></tr><tr class="v1-15-11 linux amd64 apiextensions-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux amd64 cloud-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/apiextensions-apiserver">  dl.k8s.io/v1.15.11/bin/linux/amd64/apiextensions-apiserver</a></span></td></tr><tr class="v1-15-11 linux amd64 cloud-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux amd64 hyperkube">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/cloud-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/amd64/cloud-controller-manager</a></span></td></tr><tr class="v1-15-11 linux amd64 hyperkube">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/hyperkube">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kube-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/hyperkube">  dl.k8s.io/v1.15.11/bin/linux/amd64/hyperkube</a></span></td></tr><tr class="v1-15-11 linux amd64 kube-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kube-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kube-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-apiserver">  dl.k8s.io/v1.15.11/bin/linux/amd64/kube-apiserver</a></span></td></tr><tr class="v1-15-11 linux amd64 kube-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kube-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kube-proxy">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/amd64/kube-controller-manager</a></span></td></tr><tr class="v1-15-11 linux amd64 kube-proxy">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kube-proxy">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kube-scheduler">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-proxy">  dl.k8s.io/v1.15.11/bin/linux/amd64/kube-proxy</a></span></td></tr><tr class="v1-15-11 linux amd64 kube-scheduler">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kube-scheduler">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kubeadm">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kube-scheduler">  dl.k8s.io/v1.15.11/bin/linux/amd64/kube-scheduler</a></span></td></tr><tr class="v1-15-11 linux amd64 kubeadm">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kubeadm">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubeadm">  dl.k8s.io/v1.15.11/bin/linux/amd64/kubeadm</a></span></td></tr><tr class="v1-15-11 linux amd64 kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux amd64 kubelet">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubectl">  dl.k8s.io/v1.15.11/bin/linux/amd64/kubectl</a></span></td></tr><tr class="v1-15-11 linux amd64 kubelet">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/kubelet">copy link</a></td></tr><tr class="v1-13-9 linux amd64 mounter">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/kubelet">  dl.k8s.io/v1.15.11/bin/linux/amd64/kubelet</a></span></td></tr><tr class="v1-15-11 linux amd64 mounter">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/amd64/mounter">copy link</a></td></tr><tr class="v1-13-9 linux arm apiextensions-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/amd64/mounter">  dl.k8s.io/v1.15.11/bin/linux/amd64/mounter</a></span></td></tr><tr class="v1-15-11 linux arm apiextensions-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux arm cloud-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/apiextensions-apiserver">  dl.k8s.io/v1.15.11/bin/linux/arm/apiextensions-apiserver</a></span></td></tr><tr class="v1-15-11 linux arm cloud-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/cloud-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux arm hyperkube">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/cloud-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/arm/cloud-controller-manager</a></span></td></tr><tr class="v1-15-11 linux arm hyperkube">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/hyperkube">copy link</a></td></tr><tr class="v1-13-9 linux arm kube-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/hyperkube">  dl.k8s.io/v1.15.11/bin/linux/arm/hyperkube</a></span></td></tr><tr class="v1-15-11 linux arm kube-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kube-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux arm kube-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-apiserver">  dl.k8s.io/v1.15.11/bin/linux/arm/kube-apiserver</a></span></td></tr><tr class="v1-15-11 linux arm kube-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kube-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux arm kube-proxy">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/arm/kube-controller-manager</a></span></td></tr><tr class="v1-15-11 linux arm kube-proxy">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kube-proxy">copy link</a></td></tr><tr class="v1-13-9 linux arm kube-scheduler">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-proxy">  dl.k8s.io/v1.15.11/bin/linux/arm/kube-proxy</a></span></td></tr><tr class="v1-15-11 linux arm kube-scheduler">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kube-scheduler">copy link</a></td></tr><tr class="v1-13-9 linux arm kubeadm">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kube-scheduler">  dl.k8s.io/v1.15.11/bin/linux/arm/kube-scheduler</a></span></td></tr><tr class="v1-15-11 linux arm kubeadm">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kubeadm">copy link</a></td></tr><tr class="v1-13-9 linux arm kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubeadm">  dl.k8s.io/v1.15.11/bin/linux/arm/kubeadm</a></span></td></tr><tr class="v1-15-11 linux arm kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux arm kubelet">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubectl">  dl.k8s.io/v1.15.11/bin/linux/arm/kubectl</a></span></td></tr><tr class="v1-15-11 linux arm kubelet">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/kubelet">copy link</a></td></tr><tr class="v1-13-9 linux arm mounter">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/kubelet">  dl.k8s.io/v1.15.11/bin/linux/arm/kubelet</a></span></td></tr><tr class="v1-15-11 linux arm mounter">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm/mounter">copy link</a></td></tr><tr class="v1-13-9 linux arm64 apiextensions-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm/mounter">  dl.k8s.io/v1.15.11/bin/linux/arm/mounter</a></span></td></tr><tr class="v1-15-11 linux arm64 apiextensions-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux arm64 cloud-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/apiextensions-apiserver">  dl.k8s.io/v1.15.11/bin/linux/arm64/apiextensions-apiserver</a></span></td></tr><tr class="v1-15-11 linux arm64 cloud-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux arm64 hyperkube">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/cloud-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/arm64/cloud-controller-manager</a></span></td></tr><tr class="v1-15-11 linux arm64 hyperkube">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/hyperkube">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kube-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/hyperkube">  dl.k8s.io/v1.15.11/bin/linux/arm64/hyperkube</a></span></td></tr><tr class="v1-15-11 linux arm64 kube-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kube-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kube-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-apiserver">  dl.k8s.io/v1.15.11/bin/linux/arm64/kube-apiserver</a></span></td></tr><tr class="v1-15-11 linux arm64 kube-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kube-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kube-proxy">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/arm64/kube-controller-manager</a></span></td></tr><tr class="v1-15-11 linux arm64 kube-proxy">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kube-proxy">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kube-scheduler">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-proxy">  dl.k8s.io/v1.15.11/bin/linux/arm64/kube-proxy</a></span></td></tr><tr class="v1-15-11 linux arm64 kube-scheduler">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kube-scheduler">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kubeadm">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kube-scheduler">  dl.k8s.io/v1.15.11/bin/linux/arm64/kube-scheduler</a></span></td></tr><tr class="v1-15-11 linux arm64 kubeadm">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kubeadm">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubeadm">  dl.k8s.io/v1.15.11/bin/linux/arm64/kubeadm</a></span></td></tr><tr class="v1-15-11 linux arm64 kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux arm64 kubelet">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubectl">  dl.k8s.io/v1.15.11/bin/linux/arm64/kubectl</a></span></td></tr><tr class="v1-15-11 linux arm64 kubelet">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/kubelet">copy link</a></td></tr><tr class="v1-13-9 linux arm64 mounter">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/kubelet">  dl.k8s.io/v1.15.11/bin/linux/arm64/kubelet</a></span></td></tr><tr class="v1-15-11 linux arm64 mounter">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/arm64/mounter">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le apiextensions-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/arm64/mounter">  dl.k8s.io/v1.15.11/bin/linux/arm64/mounter</a></span></td></tr><tr class="v1-15-11 linux ppc64le apiextensions-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le cloud-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/apiextensions-apiserver">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/apiextensions-apiserver</a></span></td></tr><tr class="v1-15-11 linux ppc64le cloud-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/cloud-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le hyperkube">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/cloud-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/cloud-controller-manager</a></span></td></tr><tr class="v1-15-11 linux ppc64le hyperkube">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/hyperkube">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kube-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/hyperkube">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/hyperkube</a></span></td></tr><tr class="v1-15-11 linux ppc64le kube-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kube-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kube-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-apiserver">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-apiserver</a></span></td></tr><tr class="v1-15-11 linux ppc64le kube-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kube-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kube-proxy">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-controller-manager</a></span></td></tr><tr class="v1-15-11 linux ppc64le kube-proxy">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kube-proxy">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kube-scheduler">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-proxy">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-proxy</a></span></td></tr><tr class="v1-15-11 linux ppc64le kube-scheduler">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kube-scheduler">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kubeadm">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-scheduler">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kube-scheduler</a></span></td></tr><tr class="v1-15-11 linux ppc64le kubeadm">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kubeadm">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubeadm">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubeadm</a></span></td></tr><tr class="v1-15-11 linux ppc64le kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le kubelet">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubectl">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubectl</a></span></td></tr><tr class="v1-15-11 linux ppc64le kubelet">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/kubelet">copy link</a></td></tr><tr class="v1-13-9 linux ppc64le mounter">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubelet">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/kubelet</a></span></td></tr><tr class="v1-15-11 linux ppc64le mounter">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/ppc64le/mounter">copy link</a></td></tr><tr class="v1-13-9 linux s390x apiextensions-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/ppc64le/mounter">  dl.k8s.io/v1.15.11/bin/linux/ppc64le/mounter</a></span></td></tr><tr class="v1-15-11 linux s390x apiextensions-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux s390x cloud-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/apiextensions-apiserver">  dl.k8s.io/v1.15.11/bin/linux/s390x/apiextensions-apiserver</a></span></td></tr><tr class="v1-15-11 linux s390x cloud-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/cloud-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux s390x hyperkube">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/cloud-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/s390x/cloud-controller-manager</a></span></td></tr><tr class="v1-15-11 linux s390x hyperkube">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/hyperkube">copy link</a></td></tr><tr class="v1-13-9 linux s390x kube-apiserver">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/hyperkube">  dl.k8s.io/v1.15.11/bin/linux/s390x/hyperkube</a></span></td></tr><tr class="v1-15-11 linux s390x kube-apiserver">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kube-apiserver">copy link</a></td></tr><tr class="v1-13-9 linux s390x kube-controller-manager">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-apiserver">  dl.k8s.io/v1.15.11/bin/linux/s390x/kube-apiserver</a></span></td></tr><tr class="v1-15-11 linux s390x kube-controller-manager">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kube-controller-manager">copy link</a></td></tr><tr class="v1-13-9 linux s390x kube-proxy">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-controller-manager">  dl.k8s.io/v1.15.11/bin/linux/s390x/kube-controller-manager</a></span></td></tr><tr class="v1-15-11 linux s390x kube-proxy">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kube-proxy">copy link</a></td></tr><tr class="v1-13-9 linux s390x kube-scheduler">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-proxy">  dl.k8s.io/v1.15.11/bin/linux/s390x/kube-proxy</a></span></td></tr><tr class="v1-15-11 linux s390x kube-scheduler">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kube-scheduler">copy link</a></td></tr><tr class="v1-13-9 linux s390x kubeadm">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kube-scheduler">  dl.k8s.io/v1.15.11/bin/linux/s390x/kube-scheduler</a></span></td></tr><tr class="v1-15-11 linux s390x kubeadm">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kubeadm">copy link</a></td></tr><tr class="v1-13-9 linux s390x kubectl">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubeadm">  dl.k8s.io/v1.15.11/bin/linux/s390x/kubeadm</a></span></td></tr><tr class="v1-15-11 linux s390x kubectl">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kubectl">copy link</a></td></tr><tr class="v1-13-9 linux s390x kubelet">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubectl">  dl.k8s.io/v1.15.11/bin/linux/s390x/kubectl</a></span></td></tr><tr class="v1-15-11 linux s390x kubelet">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/kubelet">copy link</a></td></tr><tr class="v1-13-9 linux s390x mounter">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/kubelet">  dl.k8s.io/v1.15.11/bin/linux/s390x/kubelet</a></span></td></tr><tr class="v1-15-11 linux s390x mounter">
+	<td>v1.15.11</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/linux/s390x/mounter">copy link</a></td></tr><tr class="v1-13-9 windows a-386 kubectl.exe">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/linux/s390x/mounter">  dl.k8s.io/v1.15.11/bin/linux/s390x/mounter</a></span></td></tr><tr class="v1-15-11 windows a-386 kubectl.exe">
+	<td>v1.15.11</td>
 	<td>windows</td>
 	<td>386</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/windows/386/kubectl.exe">copy link</a></td></tr><tr class="v1-13-9 windows amd64 kube-proxy.exe">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/windows/386/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/windows/386/kubectl.exe">  dl.k8s.io/v1.15.11/bin/windows/386/kubectl.exe</a></span></td></tr><tr class="v1-15-11 windows amd64 kube-proxy.exe">
+	<td>v1.15.11</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kube-proxy.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/windows/amd64/kube-proxy.exe">copy link</a></td></tr><tr class="v1-13-9 windows amd64 kubeadm.exe">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kube-proxy.exe">  dl.k8s.io/v1.15.11/bin/windows/amd64/kube-proxy.exe</a></span></td></tr><tr class="v1-15-11 windows amd64 kubeadm.exe">
+	<td>v1.15.11</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubeadm.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/windows/amd64/kubeadm.exe">copy link</a></td></tr><tr class="v1-13-9 windows amd64 kubectl.exe">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubeadm.exe">  dl.k8s.io/v1.15.11/bin/windows/amd64/kubeadm.exe</a></span></td></tr><tr class="v1-15-11 windows amd64 kubectl.exe">
+	<td>v1.15.11</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/windows/amd64/kubectl.exe">copy link</a></td></tr><tr class="v1-13-9 windows amd64 kubelet.exe">
-	<td>v1.13.9</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubectl.exe">  dl.k8s.io/v1.15.11/bin/windows/amd64/kubectl.exe</a></span></td></tr><tr class="v1-15-11 windows amd64 kubelet.exe">
+	<td>v1.15.11</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubelet.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.13.9/bin/windows/amd64/kubelet.exe">copy link</a></td></tr><tr class="v1-12-10 darwin a-386 kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubelet.exe">kubelet.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.15.11/bin/windows/amd64/kubelet.exe">  dl.k8s.io/v1.15.11/bin/windows/amd64/kubelet.exe</a></span></td></tr><tr class="v1-14-10 darwin a-386 kubectl">
+	<td>v1.14.10</td>
 	<td>darwin</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/darwin/386/kubectl">copy link</a></td></tr><tr class="v1-12-10 darwin amd64 kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/darwin/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/darwin/386/kubectl">  dl.k8s.io/v1.14.10/bin/darwin/386/kubectl</a></span></td></tr><tr class="v1-14-10 darwin amd64 kubectl">
+	<td>v1.14.10</td>
 	<td>darwin</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/darwin/amd64/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux a-386 kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/darwin/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/darwin/amd64/kubectl">  dl.k8s.io/v1.14.10/bin/darwin/amd64/kubectl</a></span></td></tr><tr class="v1-14-10 linux a-386 kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/386/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux amd64 apiextensions-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/386/kubectl">  dl.k8s.io/v1.14.10/bin/linux/386/kubectl</a></span></td></tr><tr class="v1-14-10 linux amd64 apiextensions-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux amd64 cloud-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/apiextensions-apiserver">  dl.k8s.io/v1.14.10/bin/linux/amd64/apiextensions-apiserver</a></span></td></tr><tr class="v1-14-10 linux amd64 cloud-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux amd64 hyperkube">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/cloud-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/amd64/cloud-controller-manager</a></span></td></tr><tr class="v1-14-10 linux amd64 hyperkube">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/hyperkube">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kube-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/hyperkube">  dl.k8s.io/v1.14.10/bin/linux/amd64/hyperkube</a></span></td></tr><tr class="v1-14-10 linux amd64 kube-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kube-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kube-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-apiserver">  dl.k8s.io/v1.14.10/bin/linux/amd64/kube-apiserver</a></span></td></tr><tr class="v1-14-10 linux amd64 kube-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kube-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kube-proxy">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/amd64/kube-controller-manager</a></span></td></tr><tr class="v1-14-10 linux amd64 kube-proxy">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kube-proxy">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kube-scheduler">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-proxy">  dl.k8s.io/v1.14.10/bin/linux/amd64/kube-proxy</a></span></td></tr><tr class="v1-14-10 linux amd64 kube-scheduler">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kube-scheduler">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kubeadm">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kube-scheduler">  dl.k8s.io/v1.14.10/bin/linux/amd64/kube-scheduler</a></span></td></tr><tr class="v1-14-10 linux amd64 kubeadm">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kubeadm">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubeadm">  dl.k8s.io/v1.14.10/bin/linux/amd64/kubeadm</a></span></td></tr><tr class="v1-14-10 linux amd64 kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux amd64 kubelet">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubectl">  dl.k8s.io/v1.14.10/bin/linux/amd64/kubectl</a></span></td></tr><tr class="v1-14-10 linux amd64 kubelet">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/kubelet">copy link</a></td></tr><tr class="v1-12-10 linux amd64 mounter">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/kubelet">  dl.k8s.io/v1.14.10/bin/linux/amd64/kubelet</a></span></td></tr><tr class="v1-14-10 linux amd64 mounter">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/amd64/mounter">copy link</a></td></tr><tr class="v1-12-10 linux arm apiextensions-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/amd64/mounter">  dl.k8s.io/v1.14.10/bin/linux/amd64/mounter</a></span></td></tr><tr class="v1-14-10 linux arm apiextensions-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux arm cloud-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/apiextensions-apiserver">  dl.k8s.io/v1.14.10/bin/linux/arm/apiextensions-apiserver</a></span></td></tr><tr class="v1-14-10 linux arm cloud-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/cloud-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux arm hyperkube">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/cloud-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/arm/cloud-controller-manager</a></span></td></tr><tr class="v1-14-10 linux arm hyperkube">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/hyperkube">copy link</a></td></tr><tr class="v1-12-10 linux arm kube-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/hyperkube">  dl.k8s.io/v1.14.10/bin/linux/arm/hyperkube</a></span></td></tr><tr class="v1-14-10 linux arm kube-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kube-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux arm kube-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-apiserver">  dl.k8s.io/v1.14.10/bin/linux/arm/kube-apiserver</a></span></td></tr><tr class="v1-14-10 linux arm kube-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kube-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux arm kube-proxy">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/arm/kube-controller-manager</a></span></td></tr><tr class="v1-14-10 linux arm kube-proxy">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kube-proxy">copy link</a></td></tr><tr class="v1-12-10 linux arm kube-scheduler">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-proxy">  dl.k8s.io/v1.14.10/bin/linux/arm/kube-proxy</a></span></td></tr><tr class="v1-14-10 linux arm kube-scheduler">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kube-scheduler">copy link</a></td></tr><tr class="v1-12-10 linux arm kubeadm">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kube-scheduler">  dl.k8s.io/v1.14.10/bin/linux/arm/kube-scheduler</a></span></td></tr><tr class="v1-14-10 linux arm kubeadm">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kubeadm">copy link</a></td></tr><tr class="v1-12-10 linux arm kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubeadm">  dl.k8s.io/v1.14.10/bin/linux/arm/kubeadm</a></span></td></tr><tr class="v1-14-10 linux arm kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux arm kubelet">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubectl">  dl.k8s.io/v1.14.10/bin/linux/arm/kubectl</a></span></td></tr><tr class="v1-14-10 linux arm kubelet">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/kubelet">copy link</a></td></tr><tr class="v1-12-10 linux arm mounter">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/kubelet">  dl.k8s.io/v1.14.10/bin/linux/arm/kubelet</a></span></td></tr><tr class="v1-14-10 linux arm mounter">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm/mounter">copy link</a></td></tr><tr class="v1-12-10 linux arm64 apiextensions-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm/mounter">  dl.k8s.io/v1.14.10/bin/linux/arm/mounter</a></span></td></tr><tr class="v1-14-10 linux arm64 apiextensions-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux arm64 cloud-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/apiextensions-apiserver">  dl.k8s.io/v1.14.10/bin/linux/arm64/apiextensions-apiserver</a></span></td></tr><tr class="v1-14-10 linux arm64 cloud-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux arm64 hyperkube">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/cloud-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/arm64/cloud-controller-manager</a></span></td></tr><tr class="v1-14-10 linux arm64 hyperkube">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/hyperkube">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kube-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/hyperkube">  dl.k8s.io/v1.14.10/bin/linux/arm64/hyperkube</a></span></td></tr><tr class="v1-14-10 linux arm64 kube-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kube-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kube-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-apiserver">  dl.k8s.io/v1.14.10/bin/linux/arm64/kube-apiserver</a></span></td></tr><tr class="v1-14-10 linux arm64 kube-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kube-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kube-proxy">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/arm64/kube-controller-manager</a></span></td></tr><tr class="v1-14-10 linux arm64 kube-proxy">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kube-proxy">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kube-scheduler">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-proxy">  dl.k8s.io/v1.14.10/bin/linux/arm64/kube-proxy</a></span></td></tr><tr class="v1-14-10 linux arm64 kube-scheduler">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kube-scheduler">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kubeadm">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kube-scheduler">  dl.k8s.io/v1.14.10/bin/linux/arm64/kube-scheduler</a></span></td></tr><tr class="v1-14-10 linux arm64 kubeadm">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kubeadm">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubeadm">  dl.k8s.io/v1.14.10/bin/linux/arm64/kubeadm</a></span></td></tr><tr class="v1-14-10 linux arm64 kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux arm64 kubelet">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubectl">  dl.k8s.io/v1.14.10/bin/linux/arm64/kubectl</a></span></td></tr><tr class="v1-14-10 linux arm64 kubelet">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/kubelet">copy link</a></td></tr><tr class="v1-12-10 linux arm64 mounter">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/kubelet">  dl.k8s.io/v1.14.10/bin/linux/arm64/kubelet</a></span></td></tr><tr class="v1-14-10 linux arm64 mounter">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/arm64/mounter">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le apiextensions-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/arm64/mounter">  dl.k8s.io/v1.14.10/bin/linux/arm64/mounter</a></span></td></tr><tr class="v1-14-10 linux ppc64le apiextensions-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le cloud-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/apiextensions-apiserver">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/apiextensions-apiserver</a></span></td></tr><tr class="v1-14-10 linux ppc64le cloud-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/cloud-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le hyperkube">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/cloud-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/cloud-controller-manager</a></span></td></tr><tr class="v1-14-10 linux ppc64le hyperkube">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/hyperkube">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kube-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/hyperkube">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/hyperkube</a></span></td></tr><tr class="v1-14-10 linux ppc64le kube-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kube-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kube-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-apiserver">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-apiserver</a></span></td></tr><tr class="v1-14-10 linux ppc64le kube-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kube-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kube-proxy">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-controller-manager</a></span></td></tr><tr class="v1-14-10 linux ppc64le kube-proxy">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kube-proxy">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kube-scheduler">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-proxy">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-proxy</a></span></td></tr><tr class="v1-14-10 linux ppc64le kube-scheduler">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kube-scheduler">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kubeadm">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-scheduler">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kube-scheduler</a></span></td></tr><tr class="v1-14-10 linux ppc64le kubeadm">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kubeadm">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubeadm">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubeadm</a></span></td></tr><tr class="v1-14-10 linux ppc64le kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le kubelet">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubectl">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubectl</a></span></td></tr><tr class="v1-14-10 linux ppc64le kubelet">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/kubelet">copy link</a></td></tr><tr class="v1-12-10 linux ppc64le mounter">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubelet">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/kubelet</a></span></td></tr><tr class="v1-14-10 linux ppc64le mounter">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/ppc64le/mounter">copy link</a></td></tr><tr class="v1-12-10 linux s390x apiextensions-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/ppc64le/mounter">  dl.k8s.io/v1.14.10/bin/linux/ppc64le/mounter</a></span></td></tr><tr class="v1-14-10 linux s390x apiextensions-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux s390x cloud-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/apiextensions-apiserver">  dl.k8s.io/v1.14.10/bin/linux/s390x/apiextensions-apiserver</a></span></td></tr><tr class="v1-14-10 linux s390x cloud-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/cloud-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux s390x hyperkube">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/cloud-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/s390x/cloud-controller-manager</a></span></td></tr><tr class="v1-14-10 linux s390x hyperkube">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/hyperkube">copy link</a></td></tr><tr class="v1-12-10 linux s390x kube-apiserver">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/hyperkube">  dl.k8s.io/v1.14.10/bin/linux/s390x/hyperkube</a></span></td></tr><tr class="v1-14-10 linux s390x kube-apiserver">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kube-apiserver">copy link</a></td></tr><tr class="v1-12-10 linux s390x kube-controller-manager">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-apiserver">  dl.k8s.io/v1.14.10/bin/linux/s390x/kube-apiserver</a></span></td></tr><tr class="v1-14-10 linux s390x kube-controller-manager">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kube-controller-manager">copy link</a></td></tr><tr class="v1-12-10 linux s390x kube-proxy">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-controller-manager">  dl.k8s.io/v1.14.10/bin/linux/s390x/kube-controller-manager</a></span></td></tr><tr class="v1-14-10 linux s390x kube-proxy">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kube-proxy">copy link</a></td></tr><tr class="v1-12-10 linux s390x kube-scheduler">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-proxy">  dl.k8s.io/v1.14.10/bin/linux/s390x/kube-proxy</a></span></td></tr><tr class="v1-14-10 linux s390x kube-scheduler">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kube-scheduler">copy link</a></td></tr><tr class="v1-12-10 linux s390x kubeadm">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kube-scheduler">  dl.k8s.io/v1.14.10/bin/linux/s390x/kube-scheduler</a></span></td></tr><tr class="v1-14-10 linux s390x kubeadm">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kubeadm">copy link</a></td></tr><tr class="v1-12-10 linux s390x kubectl">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubeadm">  dl.k8s.io/v1.14.10/bin/linux/s390x/kubeadm</a></span></td></tr><tr class="v1-14-10 linux s390x kubectl">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kubectl">copy link</a></td></tr><tr class="v1-12-10 linux s390x kubelet">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubectl">  dl.k8s.io/v1.14.10/bin/linux/s390x/kubectl</a></span></td></tr><tr class="v1-14-10 linux s390x kubelet">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/kubelet">copy link</a></td></tr><tr class="v1-12-10 linux s390x mounter">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/kubelet">  dl.k8s.io/v1.14.10/bin/linux/s390x/kubelet</a></span></td></tr><tr class="v1-14-10 linux s390x mounter">
+	<td>v1.14.10</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/linux/s390x/mounter">copy link</a></td></tr><tr class="v1-12-10 windows a-386 kubectl.exe">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/linux/s390x/mounter">  dl.k8s.io/v1.14.10/bin/linux/s390x/mounter</a></span></td></tr><tr class="v1-14-10 windows a-386 kubectl.exe">
+	<td>v1.14.10</td>
 	<td>windows</td>
 	<td>386</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/windows/386/kubectl.exe">copy link</a></td></tr><tr class="v1-12-10 windows amd64 kube-proxy.exe">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/windows/386/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/windows/386/kubectl.exe">  dl.k8s.io/v1.14.10/bin/windows/386/kubectl.exe</a></span></td></tr><tr class="v1-14-10 windows amd64 kube-proxy.exe">
+	<td>v1.14.10</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kube-proxy.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/windows/amd64/kube-proxy.exe">copy link</a></td></tr><tr class="v1-12-10 windows amd64 kubeadm.exe">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kube-proxy.exe">  dl.k8s.io/v1.14.10/bin/windows/amd64/kube-proxy.exe</a></span></td></tr><tr class="v1-14-10 windows amd64 kubeadm.exe">
+	<td>v1.14.10</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubeadm.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/windows/amd64/kubeadm.exe">copy link</a></td></tr><tr class="v1-12-10 windows amd64 kubectl.exe">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubeadm.exe">  dl.k8s.io/v1.14.10/bin/windows/amd64/kubeadm.exe</a></span></td></tr><tr class="v1-14-10 windows amd64 kubectl.exe">
+	<td>v1.14.10</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/windows/amd64/kubectl.exe">copy link</a></td></tr><tr class="v1-12-10 windows amd64 kubelet.exe">
-	<td>v1.12.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubectl.exe">  dl.k8s.io/v1.14.10/bin/windows/amd64/kubectl.exe</a></span></td></tr><tr class="v1-14-10 windows amd64 kubelet.exe">
+	<td>v1.14.10</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubelet.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.12.10/bin/windows/amd64/kubelet.exe">copy link</a></td></tr><tr class="v1-11-10 darwin a-386 kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubelet.exe">kubelet.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.14.10/bin/windows/amd64/kubelet.exe">  dl.k8s.io/v1.14.10/bin/windows/amd64/kubelet.exe</a></span></td></tr><tr class="v1-13-12 darwin a-386 kubectl">
+	<td>v1.13.12</td>
 	<td>darwin</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/darwin/386/kubectl">copy link</a></td></tr><tr class="v1-11-10 darwin amd64 kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/darwin/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/darwin/386/kubectl">  dl.k8s.io/v1.13.12/bin/darwin/386/kubectl</a></span></td></tr><tr class="v1-13-12 darwin amd64 kubectl">
+	<td>v1.13.12</td>
 	<td>darwin</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/darwin/amd64/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux a-386 kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/darwin/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/darwin/amd64/kubectl">  dl.k8s.io/v1.13.12/bin/darwin/amd64/kubectl</a></span></td></tr><tr class="v1-13-12 linux a-386 kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>386</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/386/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux amd64 apiextensions-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/386/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/386/kubectl">  dl.k8s.io/v1.13.12/bin/linux/386/kubectl</a></span></td></tr><tr class="v1-13-12 linux amd64 apiextensions-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux amd64 cloud-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/apiextensions-apiserver">  dl.k8s.io/v1.13.12/bin/linux/amd64/apiextensions-apiserver</a></span></td></tr><tr class="v1-13-12 linux amd64 cloud-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux amd64 hyperkube">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/cloud-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/amd64/cloud-controller-manager</a></span></td></tr><tr class="v1-13-12 linux amd64 hyperkube">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/hyperkube">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kube-aggregator">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/hyperkube">  dl.k8s.io/v1.13.12/bin/linux/amd64/hyperkube</a></span></td></tr><tr class="v1-13-12 linux amd64 kube-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-aggregator</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kube-aggregator">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kube-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-apiserver">  dl.k8s.io/v1.13.12/bin/linux/amd64/kube-apiserver</a></span></td></tr><tr class="v1-13-12 linux amd64 kube-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kube-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kube-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/amd64/kube-controller-manager</a></span></td></tr><tr class="v1-13-12 linux amd64 kube-proxy">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kube-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kube-proxy">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-proxy">  dl.k8s.io/v1.13.12/bin/linux/amd64/kube-proxy</a></span></td></tr><tr class="v1-13-12 linux amd64 kube-scheduler">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kube-proxy">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kube-scheduler">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kube-scheduler">  dl.k8s.io/v1.13.12/bin/linux/amd64/kube-scheduler</a></span></td></tr><tr class="v1-13-12 linux amd64 kubeadm">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kube-scheduler">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kubeadm">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubeadm">  dl.k8s.io/v1.13.12/bin/linux/amd64/kubeadm</a></span></td></tr><tr class="v1-13-12 linux amd64 kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kubeadm">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubectl">  dl.k8s.io/v1.13.12/bin/linux/amd64/kubectl</a></span></td></tr><tr class="v1-13-12 linux amd64 kubelet">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux amd64 kubelet">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/kubelet">  dl.k8s.io/v1.13.12/bin/linux/amd64/kubelet</a></span></td></tr><tr class="v1-13-12 linux amd64 mounter">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>amd64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/kubelet">copy link</a></td></tr><tr class="v1-11-10 linux amd64 mounter">
-	<td>v1.11.10</td>
-	<td>linux</td>
-	<td>amd64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/amd64/mounter">copy link</a></td></tr><tr class="v1-11-10 linux arm apiextensions-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/amd64/mounter">  dl.k8s.io/v1.13.12/bin/linux/amd64/mounter</a></span></td></tr><tr class="v1-13-12 linux arm apiextensions-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux arm cloud-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/apiextensions-apiserver">  dl.k8s.io/v1.13.12/bin/linux/arm/apiextensions-apiserver</a></span></td></tr><tr class="v1-13-12 linux arm cloud-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/cloud-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux arm hyperkube">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/cloud-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/arm/cloud-controller-manager</a></span></td></tr><tr class="v1-13-12 linux arm hyperkube">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/hyperkube">copy link</a></td></tr><tr class="v1-11-10 linux arm kube-aggregator">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/hyperkube">  dl.k8s.io/v1.13.12/bin/linux/arm/hyperkube</a></span></td></tr><tr class="v1-13-12 linux arm kube-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-aggregator</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kube-aggregator">copy link</a></td></tr><tr class="v1-11-10 linux arm kube-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-apiserver">  dl.k8s.io/v1.13.12/bin/linux/arm/kube-apiserver</a></span></td></tr><tr class="v1-13-12 linux arm kube-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kube-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux arm kube-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/arm/kube-controller-manager</a></span></td></tr><tr class="v1-13-12 linux arm kube-proxy">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kube-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux arm kube-proxy">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-proxy">  dl.k8s.io/v1.13.12/bin/linux/arm/kube-proxy</a></span></td></tr><tr class="v1-13-12 linux arm kube-scheduler">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kube-proxy">copy link</a></td></tr><tr class="v1-11-10 linux arm kube-scheduler">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kube-scheduler">  dl.k8s.io/v1.13.12/bin/linux/arm/kube-scheduler</a></span></td></tr><tr class="v1-13-12 linux arm kubeadm">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kube-scheduler">copy link</a></td></tr><tr class="v1-11-10 linux arm kubeadm">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubeadm">  dl.k8s.io/v1.13.12/bin/linux/arm/kubeadm</a></span></td></tr><tr class="v1-13-12 linux arm kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kubeadm">copy link</a></td></tr><tr class="v1-11-10 linux arm kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubectl">  dl.k8s.io/v1.13.12/bin/linux/arm/kubectl</a></span></td></tr><tr class="v1-13-12 linux arm kubelet">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux arm kubelet">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/kubelet">  dl.k8s.io/v1.13.12/bin/linux/arm/kubelet</a></span></td></tr><tr class="v1-13-12 linux arm mounter">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/kubelet">copy link</a></td></tr><tr class="v1-11-10 linux arm mounter">
-	<td>v1.11.10</td>
-	<td>linux</td>
-	<td>arm</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm/mounter">copy link</a></td></tr><tr class="v1-11-10 linux arm64 apiextensions-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm/mounter">  dl.k8s.io/v1.13.12/bin/linux/arm/mounter</a></span></td></tr><tr class="v1-13-12 linux arm64 apiextensions-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux arm64 cloud-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/apiextensions-apiserver">  dl.k8s.io/v1.13.12/bin/linux/arm64/apiextensions-apiserver</a></span></td></tr><tr class="v1-13-12 linux arm64 cloud-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/cloud-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux arm64 hyperkube">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/cloud-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/arm64/cloud-controller-manager</a></span></td></tr><tr class="v1-13-12 linux arm64 hyperkube">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/hyperkube">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kube-aggregator">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/hyperkube">  dl.k8s.io/v1.13.12/bin/linux/arm64/hyperkube</a></span></td></tr><tr class="v1-13-12 linux arm64 kube-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-aggregator</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kube-aggregator">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kube-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-apiserver">  dl.k8s.io/v1.13.12/bin/linux/arm64/kube-apiserver</a></span></td></tr><tr class="v1-13-12 linux arm64 kube-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kube-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kube-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/arm64/kube-controller-manager</a></span></td></tr><tr class="v1-13-12 linux arm64 kube-proxy">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kube-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kube-proxy">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-proxy">  dl.k8s.io/v1.13.12/bin/linux/arm64/kube-proxy</a></span></td></tr><tr class="v1-13-12 linux arm64 kube-scheduler">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kube-proxy">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kube-scheduler">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kube-scheduler">  dl.k8s.io/v1.13.12/bin/linux/arm64/kube-scheduler</a></span></td></tr><tr class="v1-13-12 linux arm64 kubeadm">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kube-scheduler">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kubeadm">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubeadm">  dl.k8s.io/v1.13.12/bin/linux/arm64/kubeadm</a></span></td></tr><tr class="v1-13-12 linux arm64 kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kubeadm">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubectl">  dl.k8s.io/v1.13.12/bin/linux/arm64/kubectl</a></span></td></tr><tr class="v1-13-12 linux arm64 kubelet">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux arm64 kubelet">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/kubelet">  dl.k8s.io/v1.13.12/bin/linux/arm64/kubelet</a></span></td></tr><tr class="v1-13-12 linux arm64 mounter">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>arm64</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/kubelet">copy link</a></td></tr><tr class="v1-11-10 linux arm64 mounter">
-	<td>v1.11.10</td>
-	<td>linux</td>
-	<td>arm64</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/arm64/mounter">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le apiextensions-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/arm64/mounter">  dl.k8s.io/v1.13.12/bin/linux/arm64/mounter</a></span></td></tr><tr class="v1-13-12 linux ppc64le apiextensions-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le cloud-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/apiextensions-apiserver">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/apiextensions-apiserver</a></span></td></tr><tr class="v1-13-12 linux ppc64le cloud-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/cloud-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le hyperkube">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/cloud-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/cloud-controller-manager</a></span></td></tr><tr class="v1-13-12 linux ppc64le hyperkube">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/hyperkube">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kube-aggregator">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/hyperkube">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/hyperkube</a></span></td></tr><tr class="v1-13-12 linux ppc64le kube-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-aggregator</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kube-aggregator">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kube-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-apiserver">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-apiserver</a></span></td></tr><tr class="v1-13-12 linux ppc64le kube-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kube-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kube-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-controller-manager</a></span></td></tr><tr class="v1-13-12 linux ppc64le kube-proxy">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kube-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kube-proxy">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-proxy">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-proxy</a></span></td></tr><tr class="v1-13-12 linux ppc64le kube-scheduler">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kube-proxy">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kube-scheduler">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-scheduler">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kube-scheduler</a></span></td></tr><tr class="v1-13-12 linux ppc64le kubeadm">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kube-scheduler">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kubeadm">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubeadm">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubeadm</a></span></td></tr><tr class="v1-13-12 linux ppc64le kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kubeadm">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubectl">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubectl</a></span></td></tr><tr class="v1-13-12 linux ppc64le kubelet">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le kubelet">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubelet">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/kubelet</a></span></td></tr><tr class="v1-13-12 linux ppc64le mounter">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>ppc64le</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/kubelet">copy link</a></td></tr><tr class="v1-11-10 linux ppc64le mounter">
-	<td>v1.11.10</td>
-	<td>linux</td>
-	<td>ppc64le</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/ppc64le/mounter">copy link</a></td></tr><tr class="v1-11-10 linux s390x apiextensions-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/ppc64le/mounter">  dl.k8s.io/v1.13.12/bin/linux/ppc64le/mounter</a></span></td></tr><tr class="v1-13-12 linux s390x apiextensions-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>apiextensions-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/apiextensions-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux s390x cloud-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/apiextensions-apiserver">  dl.k8s.io/v1.13.12/bin/linux/s390x/apiextensions-apiserver</a></span></td></tr><tr class="v1-13-12 linux s390x cloud-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>cloud-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/cloud-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux s390x hyperkube">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/cloud-controller-manager">cloud-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/cloud-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/s390x/cloud-controller-manager</a></span></td></tr><tr class="v1-13-12 linux s390x hyperkube">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>hyperkube</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/hyperkube">copy link</a></td></tr><tr class="v1-11-10 linux s390x kube-aggregator">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/hyperkube">hyperkube</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/hyperkube">  dl.k8s.io/v1.13.12/bin/linux/s390x/hyperkube</a></span></td></tr><tr class="v1-13-12 linux s390x kube-apiserver">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-aggregator</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kube-aggregator">copy link</a></td></tr><tr class="v1-11-10 linux s390x kube-apiserver">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-apiserver">kube-apiserver</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-apiserver">  dl.k8s.io/v1.13.12/bin/linux/s390x/kube-apiserver</a></span></td></tr><tr class="v1-13-12 linux s390x kube-controller-manager">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-apiserver</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kube-apiserver">copy link</a></td></tr><tr class="v1-11-10 linux s390x kube-controller-manager">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-controller-manager">  dl.k8s.io/v1.13.12/bin/linux/s390x/kube-controller-manager</a></span></td></tr><tr class="v1-13-12 linux s390x kube-proxy">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-controller-manager</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kube-controller-manager">copy link</a></td></tr><tr class="v1-11-10 linux s390x kube-proxy">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-proxy">kube-proxy</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-proxy">  dl.k8s.io/v1.13.12/bin/linux/s390x/kube-proxy</a></span></td></tr><tr class="v1-13-12 linux s390x kube-scheduler">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-proxy</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kube-proxy">copy link</a></td></tr><tr class="v1-11-10 linux s390x kube-scheduler">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-scheduler">kube-scheduler</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kube-scheduler">  dl.k8s.io/v1.13.12/bin/linux/s390x/kube-scheduler</a></span></td></tr><tr class="v1-13-12 linux s390x kubeadm">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kube-scheduler</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kube-scheduler">copy link</a></td></tr><tr class="v1-11-10 linux s390x kubeadm">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubeadm">kubeadm</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubeadm">  dl.k8s.io/v1.13.12/bin/linux/s390x/kubeadm</a></span></td></tr><tr class="v1-13-12 linux s390x kubectl">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubeadm</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kubeadm">copy link</a></td></tr><tr class="v1-11-10 linux s390x kubectl">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubectl">kubectl</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubectl">  dl.k8s.io/v1.13.12/bin/linux/s390x/kubectl</a></span></td></tr><tr class="v1-13-12 linux s390x kubelet">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubectl</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kubectl">copy link</a></td></tr><tr class="v1-11-10 linux s390x kubelet">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubelet">kubelet</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/kubelet">  dl.k8s.io/v1.13.12/bin/linux/s390x/kubelet</a></span></td></tr><tr class="v1-13-12 linux s390x mounter">
+	<td>v1.13.12</td>
 	<td>linux</td>
 	<td>s390x</td>
-	<td>kubelet</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/kubelet">copy link</a></td></tr><tr class="v1-11-10 linux s390x mounter">
-	<td>v1.11.10</td>
-	<td>linux</td>
-	<td>s390x</td>
-	<td>mounter</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/linux/s390x/mounter">copy link</a></td></tr><tr class="v1-11-10 windows a-386 kubectl.exe">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/mounter">mounter</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/linux/s390x/mounter">  dl.k8s.io/v1.13.12/bin/linux/s390x/mounter</a></span></td></tr><tr class="v1-13-12 windows a-386 kubectl.exe">
+	<td>v1.13.12</td>
 	<td>windows</td>
 	<td>386</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/windows/386/kubectl.exe">copy link</a></td></tr><tr class="v1-11-10 windows amd64 kube-proxy.exe">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/windows/386/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/windows/386/kubectl.exe">  dl.k8s.io/v1.13.12/bin/windows/386/kubectl.exe</a></span></td></tr><tr class="v1-13-12 windows amd64 kube-proxy.exe">
+	<td>v1.13.12</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kube-proxy.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/windows/amd64/kube-proxy.exe">copy link</a></td></tr><tr class="v1-11-10 windows amd64 kubeadm.exe">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kube-proxy.exe">  dl.k8s.io/v1.13.12/bin/windows/amd64/kube-proxy.exe</a></span></td></tr><tr class="v1-13-12 windows amd64 kubeadm.exe">
+	<td>v1.13.12</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubeadm.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/windows/amd64/kubeadm.exe">copy link</a></td></tr><tr class="v1-11-10 windows amd64 kubectl.exe">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubeadm.exe">  dl.k8s.io/v1.13.12/bin/windows/amd64/kubeadm.exe</a></span></td></tr><tr class="v1-13-12 windows amd64 kubectl.exe">
+	<td>v1.13.12</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubectl.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/windows/amd64/kubectl.exe">copy link</a></td></tr><tr class="v1-11-10 windows amd64 kubelet.exe">
-	<td>v1.11.10</td>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubectl.exe">kubectl.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubectl.exe">  dl.k8s.io/v1.13.12/bin/windows/amd64/kubectl.exe</a></span></td></tr><tr class="v1-13-12 windows amd64 kubelet.exe">
+	<td>v1.13.12</td>
 	<td>windows</td>
 	<td>amd64</td>
-	<td>kubelet.exe</td>
-	<td><a class="copy" href="https://storage.googleapis.com/kubernetes-release/release/v1.11.10/bin/windows/amd64/kubelet.exe">copy link</a></td></tr>
+    <td><span title="download"><a href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubelet.exe">kubelet.exe</a></span></td>
+    <td><span class="icon"><i class="fa fa-copy"></i></span><span title="copy to clipboard"><a class="copy" href="https://dl.k8s.io/v1.13.12/bin/windows/amd64/kubelet.exe">  dl.k8s.io/v1.13.12/bin/windows/amd64/kubelet.exe</a></span></td></tr>
             </tbody>
         </table>
     </section>


### PR DESCRIPTION
- change the url from storage.googleapis.com to dl.k8s.io
- change the copy link to have a fa-copy icon to make it more intuitive.
- updated the binary column to allow for direct download.
- changed the "VERSIONS" text to include "STABLE"

Signed-off-by: Duffie Cooley <cooleyd@vmware.com>